### PR TITLE
Add xfonts-utils dependency

### DIFF
--- a/wl_install_deps
+++ b/wl_install_deps
@@ -46,4 +46,5 @@ if [ ${INCLUDE_XWAYLAND} ]; then
 	sudo apt-get -y install libxext-dev
 	sudo apt-get -y install libxfixes-dev
 	sudo apt-get -y install libxxf86vm-dev
+	sudo apt-get -y install xfonts-utils
 fi


### PR DESCRIPTION
I decided to try and install using docker `debian` jesse image. Building xserver failed because xfonts-utils wasn't installed.
